### PR TITLE
Initial steps for Screenshotlayer compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,9 @@ python -m gunicorn --config ./gunicorn_config.py app:app
 Make a GET request to `/screenshot` endpoint with the following parameters:
 
 - `url` (required): The URL of the website to screenshot.
-- `viewport` (optional, default '800x600'): The viewport size.
-- `format` (optional, default 'png'): The screenshot format, supports png, jpg, jpeg.
+- `viewport` (optional, default '1440x900'): The viewport size.
+- `format` (optional, default 'PNG'): The screenshot format, supports PNG, JPG.
 - `delay` (optional, default '0'): The delay before the screenshot is taken to allow the page to load.
-- `darkmode` (optional, default 'false'): A flag to toggle dark mode for the website. Accepts 'true' or 'false'.
 
 ### Examples
 Request to capture a screenshot:

--- a/app.py
+++ b/app.py
@@ -9,22 +9,11 @@ app = Flask(__name__)
 # ALLOWED_ORIGINS=https://yourfrontenddomain1.com,https://yourfrontenddomain2.com
 ALLOWED_ORIGINS = os.environ.get('ALLOWED_ORIGINS', 'https://rahb-realtors-association.github.io').split(',')
 
-CORS(app, origins=ALLOWED_ORIGINS)
+CORS(app, resources={r"*": {"origins": ALLOWED_ORIGINS}}, supports_credentials=True)
 
 api = Api(app)
-api.add_resource(ScreenshotAPI, '/screenshot')
-
-@app.errorhandler(400)
-def handle_bad_request(e):
-    return jsonify({"message": str(e.description)}), 400
-
-@app.errorhandler(401)
-def handle_unauthorized(e):
-    return jsonify({"message": str(e.description)}), 401
-
-@app.errorhandler(500)
-def handle_internal_error(e):
-    return jsonify({"message": "An unexpected error occurred while taking the screenshot"}), 500
+api.add_resource(ScreenshotAPI, '/screenshot', endpoint='screenshot')
+api.add_resource(ScreenshotAPI, '/api/capture', endpoint='capture')
 
 if __name__ == '__main__':
     app.run(debug=True, port=5000)

--- a/docs/client.js
+++ b/docs/client.js
@@ -152,7 +152,7 @@ document.addEventListener("DOMContentLoaded", function() {
     saveButton.addEventListener("click", function(e) {
         e.preventDefault();
 
-        const format = document.querySelector("#formatBtnGroup .btn-primary").dataset.format || "PNG";
+        const format = (document.querySelector("#formatBtnGroup .btn-primary").dataset.format || "PNG").toLowerCase();
         const imageUrl = resultContainer.querySelector("img").getAttribute('src');
         const now = new Date();
         const timestamp = now.toISOString().slice(0, 10).replace(/-/g, '') + '-' + now.toISOString().slice(11, 19).replace(/:/g, '');

--- a/docs/client.js
+++ b/docs/client.js
@@ -82,8 +82,8 @@ document.addEventListener("DOMContentLoaded", function() {
         const apiUrl = apiUrlInput.value;
         const apiKey = apiKeyInput.value;
         const websiteUrlValue = websiteUrl.value;
-        const viewport = document.querySelector("#viewport").value || "1280x960";
-        const format = document.querySelector("#formatBtnGroup .btn-primary").dataset.format || "png";
+        const viewport = document.querySelector("#viewport").value || "1440x900";
+        const format = document.querySelector("#formatBtnGroup .btn-primary").dataset.format || "PNG";
         const delay = delaySlider.value || "1";
 
         // Validation
@@ -96,7 +96,7 @@ document.addEventListener("DOMContentLoaded", function() {
             return;
         }
         if (viewport && !/^\d+x\d+$/.test(viewport)) {
-            displayErrorMessage("Invalid viewport format. It should be like 1280x960.");
+            displayErrorMessage("Invalid viewport format. It should be like 1440x900.");
             return;
         }
 
@@ -152,7 +152,7 @@ document.addEventListener("DOMContentLoaded", function() {
     saveButton.addEventListener("click", function(e) {
         e.preventDefault();
 
-        const format = document.querySelector("#formatBtnGroup .btn-primary").dataset.format || "png";
+        const format = document.querySelector("#formatBtnGroup .btn-primary").dataset.format || "PNG";
         const imageUrl = resultContainer.querySelector("img").getAttribute('src');
         const now = new Date();
         const timestamp = now.toISOString().slice(0, 10).replace(/-/g, '') + '-' + now.toISOString().slice(11, 19).replace(/:/g, '');

--- a/docs/index.html
+++ b/docs/index.html
@@ -111,18 +111,18 @@
         <div class="card card-body bg-light">
             <!-- Viewport Label and Input -->
             <div class="mb-2">
-                <label for="viewport">Viewport size:</label>
+                <label for="viewport"><i class="fas fa-desktop"></i> Viewport Size</label>
                 <input class="form-control mt-2" id="viewport" placeholder="e.g. 1440x900" type="text"/>
             </div>
             
             <!-- Delay Slider and Format Buttons -->
             <div class="d-flex align-items-start justify-content-between mt-2">
                 <div class="flex-grow-1" id="delaySliderGroup">
-                    <label for="delaySlider" class="form-label">Delay:</label> <span id="delayValue">1 second</span>
+                    <label for="delaySlider" class="form-label"><i class="fas fa-clock"></i> Delay:</label> <span id="delayValue">1 second</span>
                     <input type="range" class="form-range m-2" id="delaySlider" min="1" max="20" value="1">
                 </div>
                 <div class="ml-3">
-                    <label class="form-label d-block">Format:</label>
+                    <label class="form-label d-block"><i class="fas fa-file-image"></i> Format</label>
                     <div class="btn-group" role="group" id="formatBtnGroup">
                         <button type="button" class="btn btn-primary" data-format="PNG">PNG</button>
                         <button type="button" class="btn btn-secondary" data-format="JPG">JPG</button>

--- a/docs/index.html
+++ b/docs/index.html
@@ -119,7 +119,7 @@
             <div class="d-flex align-items-start justify-content-between mt-2">
                 <div class="flex-grow-1" id="delaySliderGroup">
                     <label for="delaySlider" class="form-label">Delay:</label> <span id="delayValue">1 second</span>
-                    <input type="range" class="form-range m-2" id="delaySlider" min="1" max="30" value="1">
+                    <input type="range" class="form-range m-2" id="delaySlider" min="1" max="20" value="1">
                 </div>
                 <div class="ml-3">
                     <label class="form-label d-block">Format:</label>

--- a/docs/index.html
+++ b/docs/index.html
@@ -112,7 +112,7 @@
             <!-- Viewport Label and Input -->
             <div class="mb-2">
                 <label for="viewport">Viewport size:</label>
-                <input class="form-control mt-2" id="viewport" placeholder="e.g. 1280x960" type="text"/>
+                <input class="form-control mt-2" id="viewport" placeholder="e.g. 1440x900" type="text"/>
             </div>
             
             <!-- Delay Slider and Format Buttons -->
@@ -124,8 +124,8 @@
                 <div class="ml-3">
                     <label class="form-label d-block">Format:</label>
                     <div class="btn-group" role="group" id="formatBtnGroup">
-                        <button type="button" class="btn btn-primary" data-format="png">PNG</button>
-                        <button type="button" class="btn btn-secondary" data-format="jpg">JPG</button>
+                        <button type="button" class="btn btn-primary" data-format="PNG">PNG</button>
+                        <button type="button" class="btn btn-secondary" data-format="JPG">JPG</button>
                     </div>
                 </div>
             </div>

--- a/resources/screenshot.py
+++ b/resources/screenshot.py
@@ -33,18 +33,15 @@ class ScreenshotAPI(Resource):
             if not (0 < width <= MAX_SIZE) or not (0 < height <= MAX_SIZE):
                 abort(400, f"Invalid viewport dimensions. Dimensions must be between 1 and {MAX_SIZE}")
 
-            format = request.args.get('format', 'png')
-            if format not in ['png', 'jpg', 'jpeg']:
-                abort(400, "Invalid format. Supported formats are png, jpg, jpeg")
+            format = request.args.get('format', 'PNG').upper()
+            if format not in ['PNG', 'JPG']:
+                abort(400, "Invalid format. Supported formats are PNG, JPG")
 
             # Adding a delay with a cap
             delay = request.args.get('delay', default=0, type=int)
             MAX_DELAY = 30  # Set to your desired max delay
             if delay < 0 or delay > MAX_DELAY:
                 abort(400, f"Invalid delay. Delay must be between 0 and {MAX_DELAY}")
-
-            # Dark mode option (default: false)
-            darkmode = request.args.get('darkmode', 'false').lower() == 'true'
 
             # Setup Selenium with headless Chrome
             chrome_options = Options()
@@ -53,11 +50,6 @@ class ScreenshotAPI(Resource):
             chrome_options.add_argument("--no-sandbox")
             chrome_options.add_argument("--disable-dev-shm-usage")
             chrome_options.add_argument(f"--window-size={width},{height}")
-
-            # Add dark mode flag if requested
-            if darkmode:
-                chrome_options.add_argument("--force-dark-mode")
-                chrome_options.add_argument("--enable-features=WebUIDarkMode")
 
             driver = webdriver.Chrome(options=chrome_options)
             driver.set_page_load_timeout(30)  # set a 30-second timeout for page load

--- a/resources/screenshot.py
+++ b/resources/screenshot.py
@@ -24,7 +24,7 @@ class ScreenshotAPI(Resource):
             if not url or not validate_url(url):
                 abort(400, "Invalid or missing URL")
 
-            viewport = request.args.get('viewport', '800x600')
+            viewport = request.args.get('viewport', '1440x900')
             try:
                 width, height = map(int, viewport.split('x'))
             except ValueError:


### PR DESCRIPTION
## Summary
In this PR, we've taken significant strides towards achieving compatibility with the Screenshotlayer API. We've harmonized the API parameter values that both our service and Screenshotlayer share. Additionally, we've introduced `/api/capture` as an endpoint, mirroring Screenshotlayer's endpoint, while retaining our original `/screenshot`.

## Description
To facilitate a smoother transition for users migrating from Screenshotlayer or using both services, we've made the following changes:

- Harmonized API parameter values for common functionalities.
- Introduced `/api/capture` as an additional endpoint, allowing users familiar with Screenshotlayer to use our service without major changes in their requests.

There are still a couple of tasks remaining:
- Our error format needs to be adjusted to match that of Screenshotlayer.
- We are planning to switch from bearer token authentication to using the `access_key` parameter in requests, in line with Screenshotlayer's methodology.

## Related Issue(s)
- _None_

## Motivation and Context
These changes are foundational for ensuring our service is plug-and-play for users familiar with or transitioning from Screenshotlayer. By reducing friction in adopting our service, we hope to provide a seamless experience and cater to a broader user base.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.